### PR TITLE
Use newer targets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,17 @@
 language: objective-c
-osx_image: xcode11
+osx_image: xcode12
 env:
   before_install:
     - gem install xcpretty
   global:
     - PROJECT="FluentConstraints.xcodeproj"
     - SCHEME="FluentConstraints"
-    - SDK="iphonesimulator13.0"
+    - SDK="iphonesimulator14.0"
   matrix:
-    - DESTINATION="OS=10.3.1,name=iPhone 6"
-    - DESTINATION="OS=11.4,name=iPhone 6"
-    - DESTINATION="OS=12.2,name=iPhone 6"
-    - DESTINATION="OS=13.0,name=iPhone 8"
+    - DESTINATION="OS=11.4,name=iPhone 8"
+    - DESTINATION="OS=12.2,name=iPhone 8"
+    - DESTINATION="OS=13.0,name=iPhone 11"
+    - DESTINATION="OS=14.0,name=iPhone 11"
 script:
   - set -o pipefail
   - xcodebuild -project "$PROJECT" -scheme "$SCHEME" -sdk "$SDK" -destination "$DESTINATION" test | xcpretty -c


### PR DESCRIPTION
Updating the Travis-CI config to use newer targets now that XCode12 and iOS14 are out.